### PR TITLE
Execute on focus

### DIFF
--- a/src/BizzomateOnInput/BizzomateOnInput.xml
+++ b/src/BizzomateOnInput/BizzomateOnInput.xml
@@ -19,6 +19,11 @@
             <category>Settings</category>
             <description>You can set a delay so the onInput mf is triggered only when the user is done typing</description>
         </property>
+	<property key="executeOnFocus" type="boolean" required="true" defaultValue="false">
+            <caption>Trigger directly on focus</caption>
+            <category>Settings</category>
+            <description>Determines whether the micro/nanoflow should be executed when a user enters the inputfield</description>
+        </property>
         <property key="onInputActionType" type="enumeration" defaultValue="onInputMicroflow">
             <caption>Type of action</caption>
             <category>Settings</category>
@@ -39,11 +44,6 @@
             <category>Settings</category>
             <description>The nanoflow to trigger when the input changes</description>
             <returnType type="Void"/>
-        </property>
-		<property key="executeOnFocus" type="boolean" required="true" defaultValue="false">
-            <caption>Execute micro/nanoflow on focus</caption>
-            <category>Settings</category>
-            <description>Determines whether the micro/nanoflow should be executed when a user enters the inputfield</description>
         </property>
         <property key="onInputPlaceholder" type="translatableString" required="false">
             <caption>Placeholder</caption>

--- a/src/BizzomateOnInput/BizzomateOnInput.xml
+++ b/src/BizzomateOnInput/BizzomateOnInput.xml
@@ -40,7 +40,7 @@
             <description>The nanoflow to trigger when the input changes</description>
             <returnType type="Void"/>
         </property>
-		<property key="executeOnFocus" type="boolean" required="true" defaultValue="true">
+		<property key="executeOnFocus" type="boolean" required="true" defaultValue="false">
             <caption>Execute micro/nanoflow on focus</caption>
             <category>Settings</category>
             <description>Determines whether the micro/nanoflow should be executed when a user enters the inputfield</description>

--- a/src/BizzomateOnInput/BizzomateOnInput.xml
+++ b/src/BizzomateOnInput/BizzomateOnInput.xml
@@ -40,6 +40,11 @@
             <description>The nanoflow to trigger when the input changes</description>
             <returnType type="Void"/>
         </property>
+		<property key="executeOnFocus" type="boolean" required="true" defaultValue="true">
+            <caption>Execute micro/nanoflow on focus</caption>
+            <category>Settings</category>
+            <description>Determines whether the micro/nanoflow should be executed when a user enters the inputfield</description>
+        </property>
         <property key="onInputPlaceholder" type="translatableString" required="false">
             <caption>Placeholder</caption>
             <category>Settings</category>

--- a/src/BizzomateOnInput/widget/BizzomateOnInput.js
+++ b/src/BizzomateOnInput/widget/BizzomateOnInput.js
@@ -49,6 +49,9 @@ define([
                 dojoProp.set(this.onInputNode, "placeholder", this.onInputPlaceholder);
             }
             this.connect(this.onInputNode, "oninput", dojoLang.hitch(this, this._onInput));
+			if (this.executeOnFocus) {
+				this.connect(this.onInputNode, "onfocus", dojoLang.hitch(this, this._onInput));
+			}
 
             if (this.onInputActionType == "onInputMicroflow" && !this.onInputMicroFlow){
                 mx.ui.error(

--- a/src/BizzomateOnInput/widget/BizzomateOnInput.js
+++ b/src/BizzomateOnInput/widget/BizzomateOnInput.js
@@ -34,6 +34,7 @@ define([
         onInputMicroFlow: "",
         onInputNanoflow: "",
         onInputPlaceholder: "",
+	executeOnFocus: "",
 
         constructor: function () {
             // Uncomment the following line to enable debug messages
@@ -49,9 +50,9 @@ define([
                 dojoProp.set(this.onInputNode, "placeholder", this.onInputPlaceholder);
             }
             this.connect(this.onInputNode, "oninput", dojoLang.hitch(this, this._onInput));
-			if (this.executeOnFocus) {
-				this.connect(this.onInputNode, "onfocus", dojoLang.hitch(this, this._onInput));
-			}
+	    if (this.executeOnFocus) {
+	       this.connect(this.onInputNode, "onfocus", dojoLang.hitch(this, this._onInput));
+	    }
 
             if (this.onInputActionType == "onInputMicroflow" && !this.onInputMicroFlow){
                 mx.ui.error(


### PR DESCRIPTION
Able to configure to also execute the micro/nanoflow on focus, to immediately execute a search, even when a user hasn't typed in a search value.

Useful for example when you want to show a list of all possible options before the user enters a search value.